### PR TITLE
docs: Fix Markdown consistency with import samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ python3 -m pip install -U git+https://github.com/miyakogi/pyppeteer.git@dev
 
 ```py
 import asyncio
-from pyppeteer import launch
+from pyppeteer.launcher import launch
 
 async def main():
     browser = launch()
@@ -57,7 +57,7 @@ asyncio.get_event_loop().run_until_complete(main())
 
 ```py
 import asyncio
-from pyppeteer import launch
+from pyppeteer.launcher import launch
 
 async def main():
     browser = launch()


### PR DESCRIPTION
pyppeteer import examples had inconsistencies between README.md and  the docuemntation site: https://miyakogi.github.io/pyppeteer

- Switched README.md import examples to `from pyppeteer.launcher import launch`