### PR TITLE
Rename setRequestInterceptionEnabled to setRequestInterception

### DIFF
--- a/pyppeteer/network_manager.py
+++ b/pyppeteer/network_manager.py
@@ -76,7 +76,7 @@ class NetworkManager(EventEmitter):
         return await self._client.send('Network.setUserAgentOverride',
                                        {'userAgent': userAgent})
 
-    async def setRequestInterceptionEnabled(self, value: bool) -> None:
+    async def setRequestInterception(self, value: bool) -> None:
         """Enable request intercetion."""
         self._userRequestInterceptionEnabled = value
         await self._updateProtocolRequestInterception()

--- a/pyppeteer/page.py
+++ b/pyppeteer/page.py
@@ -147,9 +147,9 @@ class Page(EventEmitter):
         """Get frames."""
         return list(self._frames.values())
 
-    async def setRequestInterceptionEnabled(self, value: bool) -> None:
+    async def setRequestInterception(self, value: bool) -> None:
         """Enable request interception."""
-        return await self._networkManager.setRequestInterceptionEnabled(value)
+        return await self._networkManager.setRequestInterception(value)
 
     def _onCertificateError(self, event: Any) -> None:
         if not self._ignoreHTTPSErrors:

--- a/tests/test_pyppeteer.py
+++ b/tests/test_pyppeteer.py
@@ -385,7 +385,7 @@ class TestPage(unittest.TestCase):
     @unittest.skip('This test fails')
     @sync
     async def test_interception_enable(self):
-        await self.page.setRequestInterceptionEnabled(True)
+        await self.page.setRequestInterception(True)
         await self.page.goto(self.url)
 
     @sync


### PR DESCRIPTION
See GoogleChrome/puppeteer@ce005d4. While e9e99e8 fixed the client side, it didn't make the changes to the interface that were made upstream. This is a breaking change, but the absence of tickets asking about Request.respond suggests it isn't being used currently.