### PR TITLE
Don't try to send Browser.close without a connection

### DIFF
--- a/pyppeteer/launcher.py
+++ b/pyppeteer/launcher.py
@@ -165,7 +165,7 @@ class Launcher(object):
         if self._tmp_user_data_dir and os.path.exists(self._tmp_user_data_dir):
             self.waitForChromeToClose()
         else:
-            if self.connection:
+            if self.connection and self.connection._connected:
                 await self.connection.send('Browser.close')
 
 


### PR DESCRIPTION
It looks like the usual path relies on waitForChromeToClose, which forces Chrome to exit. If instead you pass `userDataDir`, it hangs when atexit fires, because killChrome tries to send `Browser.close` a second time.

From a quick read, I think this works OK in JS because the exit listener is forceKillChrome (since GoogleChrome/puppeteer@ab9b34c).

Another option is to call atexit.unregister...