### PR TITLE
Allow to pass websocket params via wsArgs

### DIFF
--- a/pyppeteer/connection.py
+++ b/pyppeteer/connection.py
@@ -36,7 +36,7 @@ class Connection(EventEmitter):
         self._sessions: Dict[str, Session] = dict()
         self.connection: Session
         self._connected = False
-        self._ws = websockets.client.connect(self._url)
+        self._ws = websockets.client.connect(self._url, max_size=None)
         self._recv_fut = asyncio.ensure_future(self._recv_loop())
         self._closeCallback: Optional[Callable[[], None]] = None
 

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -4,6 +4,7 @@
 from pathlib import Path
 from unittest import TestCase
 
+import asyncio
 from syncer import sync
 
 from pyppeteer import launch
@@ -58,6 +59,22 @@ class TestScreenShot(TestCase):
         options = {'path': 'example.unsupported'}
         with self.assertRaises(PageError, msg='mime type: unsupported'):
             await page.screenshot(options)
+
+    @sync
+    async def test_screenshot_large(self):
+        page = await self.browser.newPage()
+        await page.setViewport({
+            'width': 2000,
+            'height': 2000,
+        })
+        await page.goto('https://unsplash.com/')
+        options = {'path': str(self.target_path)}
+        self.assertFalse(self.target_path.exists())
+        await asyncio.wait_for(page.screenshot(options), 30)
+        self.assertTrue(self.target_path.exists())
+        with open(self.target_path, 'rb') as fh:
+            bytes = fh.read()
+            self.assertGreater(len(bytes), 2**20)
 
 
 class TestPDF(TestCase):


### PR DESCRIPTION
`pyppeteer.launch(..., wsArgs={ ... })`

This patch allows responses >1MB, e.g. when making large screenshots.

Context: I had an issue with making large screenshots — `await page.screenshot()` hanged forever for some pages.

Turned out websockets ignores the large incoming messages. This can be fixed via `max_size=LARGE_NUMBER` or `max_size=None` parameter to [websockets.client.connect](https://websockets.readthedocs.io/en/stable/api.html#websockets.client.connect). So I implemented a trivial fowarding from `wsArgs` to `websockets.client.connect(..., **wsArgs)`.

Or maybe it'd be better to simply hardcode `max_size=None`?

PS: You'll probably want to disable the tests in this commit, especially the `test_screenshot_large_timeout`, since it has to wait for 20 seconds on every run to confirm that the issue exists.