### PR TITLE
Events.Metrics declaration fix

### DIFF
--- a/pyppeteer/page.py
+++ b/pyppeteer/page.py
@@ -55,6 +55,7 @@ class Page(EventEmitter):
         FrameDetached='framedetached',
         FrameNavigated='framenavigated',
         Load='load',
+        Metrics='metrics',
     )
 
     PaperFormats: Dict[str, Dict[str, float]] = dict(

--- a/tests/test_pyppeteer.py
+++ b/tests/test_pyppeteer.py
@@ -188,6 +188,11 @@ class TestPyppeteer(BaseTestCase):
         self.assertEqual(self.page.url, 'https://example.com/')
 
     @sync
+    async def test_get_facebook(self):
+        await self.page.goto('https://www.facebook.com/')
+        self.assertEqual(self.page.url, 'https://www.facebook.com/')
+
+    @sync
     async def test_plain_text_depr(self):
         with self.assertWarns(DeprecationWarning):
             text = await self.page.plainText()


### PR DESCRIPTION
So... I just discovered that `await page.goto('https://facebook.com')` (and many other websites, I suppose) timeouts with an additional "never retrieved" exception:

`The AttributeError: 'types.SimpleNamespace' object has no attribute 'Metrics'`

This patch includes a missing declaration and a test.