### PR TITLE
Bug/win file access error fix

### DIFF
--- a/pyppeteer/launcher.py
+++ b/pyppeteer/launcher.py
@@ -106,7 +106,7 @@ class Launcher(object):
     def _cleanup_tmp_user_data_dir(self) -> None:
         for retry in range(100):
             if self._tmp_user_data_dir and os.path.exists(self._tmp_user_data_dir):
-                shutil.rmtree(self._tmp_user_data_dir)
+                shutil.rmtree(self._tmp_user_data_dir,ignore_errors=True)
             else:
                 break
         else:

--- a/pyppeteer/launcher.py
+++ b/pyppeteer/launcher.py
@@ -104,8 +104,13 @@ class Launcher(object):
             self.chrome_args.extend(self.options['args'])
 
     def _cleanup_tmp_user_data_dir(self) -> None:
-        if self._tmp_user_data_dir and os.path.exists(self._tmp_user_data_dir):
-            shutil.rmtree(self._tmp_user_data_dir)
+        for retry in range(100):
+            if self._tmp_user_data_dir and os.path.exists(self._tmp_user_data_dir):
+                shutil.rmtree(self._tmp_user_data_dir)
+            else:
+                break
+        else:
+            raise IOError('Unable to remove Temporary User Data')
 
     async def launch(self) -> Browser:
         """Start chrome process and return `Browser` object."""

--- a/pyppeteer/launcher.py
+++ b/pyppeteer/launcher.py
@@ -105,8 +105,9 @@ class Launcher(object):
 
     def _cleanup_tmp_user_data_dir(self) -> None:
         for retry in range(100):
-            if self._tmp_user_data_dir and os.path.exists(self._tmp_user_data_dir):
-                shutil.rmtree(self._tmp_user_data_dir,ignore_errors=True)
+            if self._tmp_user_data_dir and os.path.exists(
+                    self._tmp_user_data_dir):
+                shutil.rmtree(self._tmp_user_data_dir, ignore_errors=True)
             else:
                 break
         else:

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -51,9 +51,11 @@ class TestLauncher(unittest.TestCase):
         self.assertIn('--user-data-dir=/path/to/profile', launcher.chrome_args)
         self.assertIsNone(launcher._tmp_user_data_dir)
         
-    def test_clean_kill(self):
+    @sync
+     async def test_clean_kill(self):
         launcher = Launcher()
         self.assertTrue(os.path.exists(launcher._tmp_user_data_dir))
+        await launcher.launch()
         launcher.waitForChromeToClose()
         self.assertFalse(os.path.exists(launcher._tmp_user_data_dir))
 

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -51,11 +51,10 @@ class TestLauncher(unittest.TestCase):
         self.assertIn('--user-data-dir=/path/to/profile', launcher.chrome_args)
         self.assertIsNone(launcher._tmp_user_data_dir)
         
-    @sync
-    async def test_clean_kill(self):
-        launcher = await Launcher()
+    def test_clean_kill(self):
+        launcher = Launcher()
         self.assertTrue(os.path.exists(launcher._tmp_user_data_dir))
-        await launcher.killChrome()
+        launcher.waitForChromeToClose()
         self.assertFalse(os.path.exists(launcher._tmp_user_data_dir))
 
     @sync

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 import unittest
-import os
 
 from syncer import sync
 
@@ -49,7 +48,7 @@ class TestLauncher(unittest.TestCase):
         launcher = Launcher({'args': ['--user-data-dir=/path/to/profile']})
         self.check_default_args(launcher)
         self.assertIn('--user-data-dir=/path/to/profile', launcher.chrome_args)
-        self.assertIsNone(launcher._tmp_user_data_dir)        
+        self.assertIsNone(launcher._tmp_user_data_dir) 
 
     @sync
     async def test_close_no_connection(self):

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -48,7 +48,7 @@ class TestLauncher(unittest.TestCase):
         launcher = Launcher({'args': ['--user-data-dir=/path/to/profile']})
         self.check_default_args(launcher)
         self.assertIn('--user-data-dir=/path/to/profile', launcher.chrome_args)
-        self.assertIsNone(launcher._tmp_user_data_dir) 
+        self.assertIsNone(launcher._tmp_user_data_dir)
 
     @sync
     async def test_close_no_connection(self):

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -51,9 +51,9 @@ class TestLauncher(unittest.TestCase):
         self.assertIn('--user-data-dir=/path/to/profile', launcher.chrome_args)
         self.assertIsNone(launcher._tmp_user_data_dir)
         
-    def test_clean_kill(self):
+    @sync
+    async def test_clean_kill(self):
         launcher = Launcher()
-        self.check_default_args(launcher)
         self.assertTrue(os.path.exists(launcher._tmp_user_data_dir))
         await launcher.killChrome()
         self.assertFalse(os.path.exists(launcher._tmp_user_data_dir))

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -52,7 +52,7 @@ class TestLauncher(unittest.TestCase):
         self.assertIsNone(launcher._tmp_user_data_dir)
         
     @sync
-     async def test_clean_kill(self):
+    async def test_clean_kill(self):
         launcher = Launcher()
         self.assertTrue(os.path.exists(launcher._tmp_user_data_dir))
         await launcher.launch()

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -49,15 +49,7 @@ class TestLauncher(unittest.TestCase):
         launcher = Launcher({'args': ['--user-data-dir=/path/to/profile']})
         self.check_default_args(launcher)
         self.assertIn('--user-data-dir=/path/to/profile', launcher.chrome_args)
-        self.assertIsNone(launcher._tmp_user_data_dir)
-        
-    @sync
-    async def test_clean_up(self):
-        launcher = Launcher()
-        self.assertTrue(os.path.exists(launcher._tmp_user_data_dir))
-        browser = await launcher.launch()
-        await browser.close()
-        self.assertFalse(os.path.exists(launcher._tmp_user_data_dir))
+        self.assertIsNone(launcher._tmp_user_data_dir)        
 
     @sync
     async def test_close_no_connection(self):

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -53,7 +53,7 @@ class TestLauncher(unittest.TestCase):
         
     @sync
     async def test_clean_kill(self):
-        launcher = await launch()
+        launcher = await Launcher()
         self.assertTrue(os.path.exists(launcher._tmp_user_data_dir))
         await launcher.killChrome()
         self.assertFalse(os.path.exists(launcher._tmp_user_data_dir))

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -49,6 +49,13 @@ class TestLauncher(unittest.TestCase):
         self.check_default_args(launcher)
         self.assertIn('--user-data-dir=/path/to/profile', launcher.chrome_args)
         self.assertIsNone(launcher._tmp_user_data_dir)
+        
+    def test_clean_kill(self):
+        launcher = Launcher()
+        self.check_default_args(launcher)
+        self.assertTrue(os.path.exists(launcher._tmp_user_data_dir))
+        await launcher.killChrome()
+        self.assertFalse(os.path.exists(launcher._tmp_user_data_dir))
 
     @sync
     async def test_close_no_connection(self):

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -52,11 +52,11 @@ class TestLauncher(unittest.TestCase):
         self.assertIsNone(launcher._tmp_user_data_dir)
         
     @sync
-    async def test_clean_kill(self):
+    async def test_clean_up(self):
         launcher = Launcher()
         self.assertTrue(os.path.exists(launcher._tmp_user_data_dir))
-        await launcher.launch()
-        launcher.waitForChromeToClose()
+        browser = await launcher.launch()
+        await browser.close()
         self.assertFalse(os.path.exists(launcher._tmp_user_data_dir))
 
     @sync

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -53,7 +53,7 @@ class TestLauncher(unittest.TestCase):
         
     @sync
     async def test_clean_kill(self):
-        launcher = Launcher()
+        launcher = await launch()
         self.assertTrue(os.path.exists(launcher._tmp_user_data_dir))
         await launcher.killChrome()
         self.assertFalse(os.path.exists(launcher._tmp_user_data_dir))

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import unittest
+import os
 
 from syncer import sync
 


### PR DESCRIPTION
Without these changes I get this error when I end a session : 

```
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "C:\Users\%USER%\AppData\Local\Programs\Python\Python36-32\lib\site-packages\pyppeteer\launcher.py", line 171, in killChrome
    self.waitForChromeToClose()
  File "C:\Users\%USER%\AppData\Local\Programs\Python\Python36-32\lib\site-packages\pyppeteer\launcher.py", line 165, in waitForChromeToClose
    self._cleanup_tmp_user_data_dir()
  File "C:\Users\%USER%\AppData\Local\Programs\Python\Python36-32\lib\site-packages\pyppeteer\launcher.py", line 109, in _cleanup_tmp_user_data_dir
    shutil.rmtree(self._tmp_user_data_dir)
  File "C:\Users\%USER%\AppData\Local\Programs\Python\Python36-32\lib\shutil.py", line 494, in rmtree
    return _rmtree_unsafe(path, onerror)
  File "C:\Users\%USER%\AppData\Local\Programs\Python\Python36-32\lib\shutil.py", line 389, in _rmtree_unsafe
    onerror(os.unlink, fullname, sys.exc_info())
  File "C:\Users\%USER%\AppData\Local\Programs\Python\Python36-32\lib\shutil.py", line 387, in _rmtree_unsafe
    os.unlink(fullname)
PermissionError: [WinError 5] Access is denied: 'C:\\Users\\%USER%\\.pyppeteer\\.dev_profile\\tmpycqpj0jy\\CrashpadMetrics-active.pma'
```

These changes just mean it ends up closing nicely as after a couple attempts (havn't measured) it does end up able to remove the directory.