### PR TITLE
solve the invalid state caused by websocket connection closed

### DIFF
--- a/pyppeteer/connection.py
+++ b/pyppeteer/connection.py
@@ -213,7 +213,8 @@ class CDPSession(EventEmitter):
                 )
             else:
                 result = obj.get('result')
-                callback.set_result(result)
+                if callback and not callback.done():
+                    callback.set_result(result)
         else:
             self.emit(obj.get('method'), obj.get('params'))
 


### PR DESCRIPTION
add a check for callback.done() before callback.set_result() call