### PR TITLE
Add try/except to rerun()

### DIFF
--- a/pyppeteer/frame_manager.py
+++ b/pyppeteer/frame_manager.py
@@ -893,7 +893,6 @@ class WaitTask(object):
             await success.dispose()
             return
 
-
         # page is navigated and context is destroyed.
         # Try again in the new execution context.
         if (isinstance(error, NetworkError) and


### PR DESCRIPTION
Add try/except referring to puppeteer.
NetworkError frequently occurs if you don't try/except.