### PR TITLE
Fix compile problem for Python 3.4.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,5 +90,5 @@ setup(
     python_requires='>=3.5',
     test_suite='tests',
     tests_require=test_requirements,
-    **extra_args,
+    **extra_args
 )


### PR DESCRIPTION
Get error when installing:

```
$ python setup.py install
  File "setup.py", line 93
    **extra_args,
                ^
SyntaxError: invalid syntax
```

This is because of trailing comma 