### PR TITLE
Ignore cookies in generateRequestHash. Fix #140

### DIFF
--- a/pyppeteer/network_manager.py
+++ b/pyppeteer/network_manager.py
@@ -754,6 +754,7 @@ def generateRequestHash(request: dict) -> str:
                 'accept',
                 'referer',
                 'x-devtools-emulate-network-conditions-client-id',
+                'cookie',
             ]:
                 continue
             _hash['headers'][header] = headerValue


### PR DESCRIPTION
Cookies sometimes messes up the request hash.

Puppeteer also ignores cookies:
https://github.com/GoogleChrome/puppeteer/blob/4e48dfc7a195331ab1ff987d98290a6ab060a353/lib/NetworkManager.js#L668