### PR TITLE
Fix redirect response when interception is enabled

### DIFF
--- a/pyppeteer/network_manager.py
+++ b/pyppeteer/network_manager.py
@@ -165,8 +165,8 @@ class NetworkManager(EventEmitter):
             if request:
                 self._handleRequestRedirect(
                     request,
-                    event.get('redirectStatusCode', 0),
-                    event.get('redirectHeaders', {}),
+                    event.get('responseStatusCode', 0),
+                    event.get('responseHeaders', {}),
                     False,
                     False,
                     None,


### PR DESCRIPTION
The keys in the event are wrong.

See https://chromedevtools.github.io/devtools-protocol/tot/Network/#event-requestIntercepted