### PR TITLE
Fixes (ignores) SSL certificate error on Windows

### DIFF
--- a/pyppeteer/chromium_downloader.py
+++ b/pyppeteer/chromium_downloader.py
@@ -76,7 +76,7 @@ def download_zip(url: str) -> BytesIO:
     # see https://urllib3.readthedocs.io/en/latest/advanced-usage.html for more
     urllib3.disable_warnings()
 
-    with urllib3.PoolManager() as http:
+    with urllib3.PoolManager(cert_reqs='CERT_NONE') as http:
         # Get data from url.
         # set preload_content=False means using stream later.
         data = http.request('GET', url, preload_content=False)


### PR DESCRIPTION
Adds explicit ignoring of SSL certificate errors when downloading Chromium either when running the first time or through `pyppeteer-install` to avoid the following error (on Win x64):

```
SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1056)'))
```