### PR TITLE
Add WaitTask.cancel() method

### DIFF
--- a/pyppeteer/frame_manager.py
+++ b/pyppeteer/frame_manager.py
@@ -855,6 +855,11 @@ class WaitTask(object):
             raise result
         return result
 
+    def cancel(self) -> None:
+        """Cancel this task."""
+        self.promise.set_result(None)
+        self._cleanup()
+
     def terminate(self, error: Exception) -> None:
         """Terminate this task."""
         self._terminated = True
@@ -912,7 +917,9 @@ class WaitTask(object):
                 'Cannot find context with specified id' in error.args[0]):
             return
 
-        if error:
+        if self.promise.done():
+            return
+        elif error:
             self.promise.set_exception(error)
         else:
             self.promise.set_result(success)


### PR DESCRIPTION
This commit makes it possible to cancel a `WaitTask` when it is known that the task will raise a `TimeoutError.` For example:

```python
import asyncio
from concurrent.futures import FIRST_COMPLETED
from pyppeteer import launch

browser = await launch()
page = await browser.newPage()

...

tasks = [
    page.waitForXPath(<first possible xpath>),
    page.waitForXPath(<second possible xpath>),
]

# wait either of two tasks to finish
done, pending = await asyncio.wait(tasks, returh_when=FIRST_COMPLETED)

for task in tasks:
    if not task.promise.done():
        task.cancel()  # WaitTask.canel() method

for future in pending:
    future.cancel()
```
