### PR TITLE
add no-sandbox option to launch

### DIFF
--- a/pyppeteer/launcher.py
+++ b/pyppeteer/launcher.py
@@ -408,6 +408,7 @@ def defaultArgs(options: Dict = None, **kwargs: Any) -> List[str]:  # noqa: C901
     options = merge_dict(options, kwargs)
     devtools = options.get('devtools', False)
     headless = options.get('headless', not devtools)
+    noSandbox = options.get('noSandbox', False)
     args = options.get('args', list())
     userDataDir = options.get('userDataDir')
     chromeArguments = copy(DEFAULT_ARGS)
@@ -424,6 +425,8 @@ def defaultArgs(options: Dict = None, **kwargs: Any) -> List[str]:  # noqa: C901
         ))
         if current_platform().startswith('win'):
             chromeArguments.append('--disable-gpu')
+    if noSandbox:
+        chromeArguments.append('--no-sandbox')
 
     if all(map(lambda arg: arg.startswith('-'), args)):  # type: ignore
         chromeArguments.append('about:blank')


### PR DESCRIPTION
add no-sandbox option to launch to avoid

[1015/195510.670960:ERROR:zygote_host_impl_linux.cc(89)] Running as root without --no-sandbox is not supported. See https://crbug.com/638180.

When running pyppeteer as root on Linux