### PR TITLE
Fix the typing hint for the return of Page.cookies()

### DIFF
--- a/pyppeteer/page.py
+++ b/pyppeteer/page.py
@@ -470,7 +470,7 @@ class Page(EventEmitter):
     #: alias to :meth:`xpath`
     Jx = xpath
 
-    async def cookies(self, *urls: str) -> dict:
+    async def cookies(self, *urls: str) -> List[Dict[str, Union[str, int, bool]]]:
         """Get cookies.
 
         If no URLs are specified, this method returns cookies for the current


### PR DESCRIPTION
This PR try to fix the typing hint for the return of Page.cookies().

From the docstring it is said:

> If no URLs are specified, this method returns cookies for the current page URL. If URLs are specified, only cookies for those URLs are returned.
> 
> Returned cookies are **list of dictionaries** which contain these fields:
...

And also I have tested this method, the result shows the return is a list of dictionaries.