### PR TITLE
Handle global context errors (i.e. with no callback id)

### DIFF
--- a/pyppeteer/connection.py
+++ b/pyppeteer/connection.py
@@ -261,6 +261,14 @@ class CDPSession(EventEmitter):
                     result = obj.get('result')
                     if callback and not callback.done():
                         callback.set_result(result)
+        elif obj.get('error'):
+            for callback in self._callbacks.values():
+                callback.set_exception(_createProtocolError(
+                    callback.error,  # type: ignore
+                    callback.method,  # type: ignore
+                    obj,
+                ))
+            self._callbacks = {}
         else:
             params = obj.get('params', {})
             if obj.get('method') == 'Target.receivedMessageFromTarget':


### PR DESCRIPTION
Those global errors arise from, for example, invalid JSON supplied to evaluateHandle().

Current pyppeteer revision just waits forever when that happens, because error happens on CDP level, not on callback level.

While it is possible to recover from such situation, it's somewhat hard to know what command caused the error. This patch just aborts all in-flight callbacks - which works for me but may not be the optimal way to handle such errors.